### PR TITLE
Dockerfile: Use ADD instead of wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ ENV DOCKER_BUILDKIT=1 \
     BUILDX_VERSION=0.5.1
 
 ARG BUILDX_URL="https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64"
-RUN mkdir -p ~/.docker && echo '{"experimental": "enabled"}' > ~/.docker/config.json \
-    && mkdir -p $HOME/.docker/cli-plugins/ && wget -O $HOME/.docker/cli-plugins/docker-buildx $BUILDX_URL \
+ARG HOME=/root
+ADD $BUILDX_URL $HOME/.docker/cli-plugins/docker-buildx
+RUN echo '{"experimental": "enabled"}' > ~/.docker/config.json \
     && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
 
 ENTRYPOINT [ "/usr/local/bin/docker" , "buildx"]


### PR DESCRIPTION
Using Docker's built-in ADD is more reliable that using wget, which
will fail when I run behind a proxy.

Signed-off-by: Joakim Roubert <joakim.roubert@axis.com>