### PR TITLE
Dockerfile: strip binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
 # syntax=docker/dockerfile:1.2
 
+ARG ALPINE_VERSION=latest
 ARG BUILDX_VERSION=latest
 ARG DOCKER_VERSION=latest
 
 FROM docker/buildx-bin:$BUILDX_VERSION as buildx_bin
+
+FROM alpine:$ALPINE_VERSION as buildx_strip
+
+COPY --from=buildx_bin /buildx /
+RUN apk add -U binutils && strip /buildx
 
 FROM docker:$DOCKER_VERSION as buildx_image
 
 ARG DOCKER_CONFIG=/env_configs/.docker
 
 ENV DOCKER_CONFIG=$DOCKER_CONFIG \
-    DOCKER_CLI_EXPERIMENTAL="enabled"
+    DOCKER_CLI_EXPERIMENTAL=enabled
 
 WORKDIR $DOCKER_CONFIG/cli-plugins
 
-COPY --from=buildx_bin /buildx ./docker-buildx
+COPY --from=buildx_strip /buildx ./docker-buildx
 
 ENTRYPOINT [ "/usr/local/bin/docker" , "buildx"]
 


### PR DESCRIPTION
- Decrease image size by stripping `docker-buildx` binary
- Using `docker/buildx-bin` as binary source mitigates the issue with `wget` behind HTTP/1.1 proxies
- Use multistage build to keep size at a minimum
- Use specific tags (not `latest`) for base images according to best practice recommendations

Signed-off-by: Joakim Roubert <joakim.roubert@axis.com>