### PR TITLE
Dockerfile: Get docker-buildx from official binary image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
+ARG DOCKER_CONFIG=/env_configs/.docker
+ARG BUILDX_VERSION=0.6.0
+
+FROM docker/buildx-bin:$BUILDX_VERSION as buildx_bin
+
 FROM docker:latest as buildx_image
 
-ARG DOCKER_CONFIG=/env_configs/.docker
-
+ARG DOCKER_CONFIG
 ENV DOCKER_CONFIG=$DOCKER_CONFIG \
     DOCKER_CLI_EXPERIMENTAL="enabled"
 
 WORKDIR $DOCKER_CONFIG/cli-plugins
 
-COPY --from=docker/buildx-bin:0.6.0 /buildx ./docker-buildx
+COPY --from=buildx_bin /buildx ./docker-buildx
 
 ENTRYPOINT [ "/usr/local/bin/docker" , "buildx"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 FROM docker:latest as buildx_image
 
 ARG DOCKER_CONFIG=/env_configs/.docker
-ARG BUILDX_VERSION=0.6.0
-ARG BUILDX_URL="https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64"
 
 ENV DOCKER_CONFIG=$DOCKER_CONFIG \
     DOCKER_CLI_EXPERIMENTAL="enabled"
 
 WORKDIR $DOCKER_CONFIG/cli-plugins
 
-RUN wget -O ./docker-buildx $BUILDX_URL \
-    && chmod a+x ./docker-buildx
+COPY --from=docker/buildx-bin:0.6.0 /buildx ./docker-buildx
 
 ENTRYPOINT [ "/usr/local/bin/docker" , "buildx"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG DOCKER_CONFIG=/env_configs/.docker
 ARG BUILDX_VERSION=0.6.0
 
 FROM docker/buildx-bin:$BUILDX_VERSION as buildx_bin
 
 FROM docker:latest as buildx_image
 
-ARG DOCKER_CONFIG
+ARG DOCKER_CONFIG=/env_configs/.docker
+
 ENV DOCKER_CONFIG=$DOCKER_CONFIG \
     DOCKER_CLI_EXPERIMENTAL="enabled"
 


### PR DESCRIPTION
_(With inspiration from reading https://www.docker.com/blog/engineering-update-buildkit-0-9-and-docker-buildx-0-6-releases/)_

Docker now ships the docker-buildx in a binary-only Docker image
(https://hub.docker.com/r/docker/buildx-bin):

_&ldquo;This image is non-runnable and only contains the buildx binary to be able to use it in your Dockerfile.&rdquo;_

That seems like a perfect match for the dind-buildx Dockerfile.
