### PR TITLE
hooks: Shell script cleanup

### DIFF
--- a/hooks/scripts/release
+++ b/hooks/scripts/release
@@ -1,8 +1,8 @@
-#!/bin/bash -x
+#!/bin/sh -x
 
-if [ "$DOCKER_VERSION" != "latest" ]
+if [ "$DOCKER_VERSION" != latest ]
 then
-    gh release create -n "" -t "" "v$DOCKER_VERSION-$BUILDX_VERSION"
+    gh release create -n '' -t '' "v$DOCKER_VERSION-$BUILDX_VERSION"
 fi
 
 exit 0

--- a/hooks/scripts/set_tags
+++ b/hooks/scripts/set_tags
@@ -1,20 +1,20 @@
-#!/bin/bash -x
+#!/bin/sh -x
 
-BUILDX_VERSION=$(curl -s 'https://api.github.com/repos/docker/buildx/releases' | jq -r '.[0].tag_name' | sed -e "s/^v//")
-DOCKER_VERSION=$(curl -s 'https://api.github.com/repos/moby/moby/releases' | jq -r '.[0].tag_name' | sed -e "s/^v//")
-DOCKER_TAG="docker_$DOCKER_VERSION-buildx_$BUILDX_VERSION"
+BUILDX_VERSION=$(curl -s 'https://api.github.com/repos/docker/buildx/releases' | jq -r '.[0].tag_name' | sed -e 's/^v//')
+DOCKER_VERSION=$(curl -s 'https://api.github.com/repos/moby/moby/releases' | jq -r '.[0].tag_name' | sed -e 's/^v//')
+DOCKER_TAG=docker_$DOCKER_VERSION-buildx_$BUILDX_VERSION
 
 DOCKER_LABEL=latest
-if [ "$GITHUB_EVENT" = "schedule" ]
+if [ "$GITHUB_EVENT" = schedule ]
 then 
-    DOCKER_LABEL="nightly" 
+    DOCKER_LABEL=nightly
 fi
 
 if docker pull "docker:$DOCKER_VERSION" 2>/dev/null && docker pull "docker/buildx-bin:$BUILDX_VERSION" 2>/dev/null;
 then
-    echo "docker:$DOCKER_VERSION and buildx:$BUILDX_VERSION exists"
+    echo "docker:$DOCKER_VERSION and buildx:$BUILDX_VERSION exist"
 else
-    echo "docker:$DOCKER_VERSION or buildx:$BUILDX_VERSION doesnt exist"
+    echo "docker:$DOCKER_VERSION or buildx:$BUILDX_VERSION doesn't exist"
     DOCKER_TAG=$DOCKER_LABEL
     DOCKER_VERSION=latest
     BUILDX_VERSION=latest


### PR DESCRIPTION
- No need to explicitly use bash here, go POSIX instead
- Only use double quotes for expressions with variables to be expanded
- Quotes are superfluous on assignments
